### PR TITLE
Setup friendly_id

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@
 .idea/
 *.iml
 .vscode/
+
+# OS
+.DS_Store

--- a/config/initializers/friendly_id.rb
+++ b/config/initializers/friendly_id.rb
@@ -1,0 +1,107 @@
+# FriendlyId Global Configuration
+#
+# Use this to set up shared configuration options for your entire application.
+# Any of the configuration options shown here can also be applied to single
+# models by passing arguments to the `friendly_id` class method or defining
+# methods in your model.
+#
+# To learn more, check out the guide:
+#
+# http://norman.github.io/friendly_id/file.Guide.html
+
+FriendlyId.defaults do |config|
+  # ## Reserved Words
+  #
+  # Some words could conflict with Rails's routes when used as slugs, or are
+  # undesirable to allow as slugs. Edit this list as needed for your app.
+  config.use :reserved
+
+  config.reserved_words = %w(new edit index session login logout users admin
+    stylesheets assets javascripts images)
+    
+  # This adds an option to treat reserved words as conflicts rather than exceptions.
+  # When there is no good candidate, a UUID will be appended, matching the existing
+  # conflict behavior.
+
+  # config.treat_reserved_as_conflict = true
+
+  #  ## Friendly Finders
+  #
+  # Uncomment this to use friendly finders in all models. By default, if
+  # you wish to find a record by its friendly id, you must do:
+  #
+  #    MyModel.friendly.find('foo')
+  #
+  # If you uncomment this, you can do:
+  #
+  #    MyModel.find('foo')
+  #
+  # This is significantly more convenient but may not be appropriate for
+  # all applications, so you must explicity opt-in to this behavior. You can
+  # always also configure it on a per-model basis if you prefer.
+  #
+  # Something else to consider is that using the :finders addon boosts
+  # performance because it will avoid Rails-internal code that makes runtime
+  # calls to `Module.extend`.
+  #
+  # config.use :finders
+  #
+  # ## Slugs
+  #
+  # Most applications will use the :slugged module everywhere. If you wish
+  # to do so, uncomment the following line.
+  #
+  # config.use :slugged
+  #
+  # By default, FriendlyId's :slugged addon expects the slug column to be named
+  # 'slug', but you can change it if you wish.
+  #
+  # config.slug_column = 'slug'
+  #
+  # By default, slug has no size limit, but you can change it if you wish.
+  #
+  # config.slug_limit = 255
+  #
+  # When FriendlyId can not generate a unique ID from your base method, it appends
+  # a UUID, separated by a single dash. You can configure the character used as the
+  # separator. If you're upgrading from FriendlyId 4, you may wish to replace this
+  # with two dashes.
+  #
+  # config.sequence_separator = '-'
+  #
+  # Note that you must use the :slugged addon **prior** to the line which
+  # configures the sequence separator, or else FriendlyId will raise an undefined
+  # method error.
+  #
+  #  ## Tips and Tricks
+  #
+  #  ### Controlling when slugs are generated
+  #
+  # As of FriendlyId 5.0, new slugs are generated only when the slug field is
+  # nil, but if you're using a column as your base method can change this
+  # behavior by overriding the `should_generate_new_friendly_id?` method that
+  # FriendlyId adds to your model. The change below makes FriendlyId 5.0 behave
+  # more like 4.0.
+  # Note: Use(include) Slugged module in the config if using the anonymous module.
+  # If you have `friendly_id :name, use: slugged` in the model, Slugged module
+  # is included after the anonymous module defined in the initializer, so it
+  # overrides the `should_generate_new_friendly_id?` method from the anonymous module.
+  #
+  # config.use :slugged
+  # config.use Module.new {
+  #   def should_generate_new_friendly_id?
+  #     slug.blank? || <your_column_name_here>_changed?
+  #   end
+  # }
+  #
+  # FriendlyId uses Rails's `parameterize` method to generate slugs, but for
+  # languages that don't use the Roman alphabet, that's not usually sufficient.
+  # Here we use the Babosa library to transliterate Russian Cyrillic slugs to
+  # ASCII. If you use this, don't forget to add "babosa" to your Gemfile.
+  #
+  # config.use Module.new {
+  #   def normalize_friendly_id(text)
+  #     text.to_slug.normalize! :transliterations => [:russian, :latin]
+  #   end
+  # }
+end

--- a/db/migrate/20220528042012_create_friendly_id_slugs.rb
+++ b/db/migrate/20220528042012_create_friendly_id_slugs.rb
@@ -1,0 +1,21 @@
+MIGRATION_CLASS =
+  if ActiveRecord::VERSION::MAJOR >= 5
+    ActiveRecord::Migration["#{ActiveRecord::VERSION::MAJOR}.#{ActiveRecord::VERSION::MINOR}"]
+  else
+    ActiveRecord::Migration
+  end
+
+class CreateFriendlyIdSlugs < MIGRATION_CLASS
+  def change
+    create_table :friendly_id_slugs do |t|
+      t.string   :slug,           :null => false
+      t.integer  :sluggable_id,   :null => false
+      t.string   :sluggable_type, :limit => 50
+      t.string   :scope
+      t.datetime :created_at
+    end
+    add_index :friendly_id_slugs, [:sluggable_type, :sluggable_id]
+    add_index :friendly_id_slugs, [:slug, :sluggable_type], length: { slug: 140, sluggable_type: 50 }
+    add_index :friendly_id_slugs, [:slug, :sluggable_type, :scope], length: { slug: 70, sluggable_type: 50, scope: 70 }, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,63 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_02_04_052719) do
+ActiveRecord::Schema[7.0].define(version: 2022_05_28_042012) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "plpgsql"
+
+  create_table "active_storage_attachments", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "record_type", null: false
+    t.bigint "record_id", null: false
+    t.bigint "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table "active_storage_blobs", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "filename", null: false
+    t.string "content_type"
+    t.text "metadata"
+    t.string "service_name", null: false
+    t.bigint "byte_size", null: false
+    t.string "checksum"
+    t.datetime "created_at", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
+  create_table "active_storage_variant_records", force: :cascade do |t|
+    t.bigint "blob_id", null: false
+    t.string "variation_digest", null: false
+    t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
+  create_table "friendly_id_slugs", force: :cascade do |t|
+    t.string "slug", null: false
+    t.integer "sluggable_id", null: false
+    t.string "sluggable_type", limit: 50
+    t.string "scope"
+    t.datetime "created_at"
+    t.index ["slug", "sluggable_type", "scope"], name: "index_friendly_id_slugs_on_slug_and_sluggable_type_and_scope", unique: true
+    t.index ["slug", "sluggable_type"], name: "index_friendly_id_slugs_on_slug_and_sluggable_type"
+    t.index ["sluggable_type", "sluggable_id"], name: "index_friendly_id_slugs_on_sluggable_type_and_sluggable_id"
+  end
+
+  create_table "posts", force: :cascade do |t|
+    t.string "title", null: false
+    t.string "slug"
+    t.date "published_at"
+    t.date "modified_at"
+    t.boolean "published", default: false, null: false
+    t.bigint "user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["slug"], name: "index_posts_on_slug", unique: true
+    t.index ["title"], name: "index_posts_on_title", unique: true
+    t.index ["user_id"], name: "index_posts_on_user_id"
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
@@ -34,4 +87,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_02_04_052719) do
     t.index ["username"], name: "index_users_on_username", unique: true
   end
 
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "posts", "users"
 end


### PR DESCRIPTION
This sets up friendly_id for generating human-friendly slugs for relevant resources.

Signed-off-by: mc962 <11969409+mc962@users.noreply.github.com>